### PR TITLE
Fix: integrity validation

### DIFF
--- a/demo/deepin-compatibility-mode-container
+++ b/demo/deepin-compatibility-mode-container
@@ -34,5 +34,5 @@ podman images 2>&1 | grep v20.8-compatible &>/dev/null ||
 echo '{
         "name": "deepin-v20",
         "image": "linuxdeepin/apricot:v20.8-compatible",
-        "imageHash": "6b03b24c2d82a505e43551eaa877f321672aaa5b3ee9bdaae2cf894572a0cd31"
+        "imageId": "6b03b24c2d82a505e43551eaa877f321672aaa5b3ee9bdaae2cf894572a0cd31"
 }'

--- a/demo/deepin-compatibility-mode-container
+++ b/demo/deepin-compatibility-mode-container
@@ -33,5 +33,6 @@ podman images 2>&1 | grep v20.8-compatible &>/dev/null ||
 
 echo '{
         "name": "deepin-v20",
-        "image": "linuxdeepin/apricot:v20.8-compatible"
+        "image": "linuxdeepin/apricot:v20.8-compatible",
+        "imageHash": "6b03b24c2d82a505e43551eaa877f321672aaa5b3ee9bdaae2cf894572a0cd31"
 }'

--- a/demo/deepin-compatibility-mode-start
+++ b/demo/deepin-compatibility-mode-start
@@ -36,7 +36,7 @@ main() {
 
 	container_name=$(echo "$container" | jq -r ".name")
 
-	container_image_hash=$(echo "$container" | jq -r ".imageHash")
+	container_image_id=$(echo "$container" | jq -r ".imageId")
 
 	if ! distrobox-list | grep "$container_name" &>/dev/null; then
 		if ! distrobox create -Y \
@@ -70,9 +70,9 @@ main() {
 		fi
 	fi
 
-	if [ "$(podman inspect "$container_name" | jq -r '.[0].Image')" != "$container_image_hash" ]; then
+	if [ "$(podman inspect "$container_name" | jq -r '.[0].Image')" != "$container_image_id" ]; then
 		notify-send 'deepin V20 compatibility mode' \
-			'Refused to run container '"$container_name"' with incorrect image hash.' \
+			'Refused to run container '"$container_name"' with incorrect image ID.' \
 			--icon=dialog-information
 		exit 255
 	fi

--- a/demo/deepin-compatibility-mode-start
+++ b/demo/deepin-compatibility-mode-start
@@ -36,11 +36,21 @@ main() {
 
 	container_name=$(echo "$container" | jq -r ".name")
 
+	container_image=$(echo "$container" | jq -r ".image")
+
 	container_image_id=$(echo "$container" | jq -r ".imageId")
 
 	if ! distrobox-list | grep "$container_name" &>/dev/null; then
+		podman_images_json="$(podman images --format json)"
+		if { ! echo "$podman_images_json" | jq -r 'map(.Id) | join("\n")' | grep "$container_image_id" &> /dev/null; } && { echo "$podman_images_json" | jq -r 'map(.Names | select(. != null) | join("\n")) | join("\n")' | grep "$container_image" &> /dev/null; }; then
+			notify-send 'deepin V20 compatibility mode' \
+				'Refused to use image '"$container_image"' with incorrect ID.' \
+				--icon=dialog-information
+			exit 255
+		fi
+
 		if ! distrobox create -Y \
-			-i "$(echo "$container" | jq -r ".image")" \
+			-i "$container_image_id" \
 			-n "$container_name" \
 			--additional-flags \
 			"--env LANG=$LANG --env LC_COLLATE=$LC_COLLATE --env LC_CTYPE=$LC_CTYPE --env LC_MONETARY=$LC_MONETARY --env LC_MESSAGES=$LC_MESSAGES --env LC_NUMERIC=$LC_NUMERIC --env LC_TIME=$LC_TIME --env LC_ALL=$LC_ALL" \

--- a/demo/deepin-compatibility-mode-start
+++ b/demo/deepin-compatibility-mode-start
@@ -36,6 +36,8 @@ main() {
 
 	container_name=$(echo "$container" | jq -r ".name")
 
+	container_image_hash=$(echo "$container" | jq -r ".imageHash")
+
 	if ! distrobox-list | grep "$container_name" &>/dev/null; then
 		if ! distrobox create -Y \
 			-i "$(echo "$container" | jq -r ".image")" \
@@ -66,6 +68,13 @@ main() {
 				'Failed to load application.' \
 				--icon=dialog-information
 		fi
+	fi
+
+	if [ "$(podman inspect "$container_name" | jq -r '.[0].Image')" != "$container_image_hash" ]; then
+		notify-send 'deepin V20 compatibility mode' \
+			'Refused to run container '"$container_name"' with incorrect image hash.' \
+			--icon=dialog-information
+		exit 255
 	fi
 
 	if [ $# -eq 0 ]; then


### PR DESCRIPTION
This pull request addresses the root cause of the issue mentioned by shenmo in https://bbs.deepin.org/post/257050 and various security concerns raised in https://bbs.deepin.org/zh/post/257061 , by using the image ID for validation and container creation as opposed to the image name: 

- When the `linuxdeepin/apricot:v20.8-compatible` image exists locally under a different name, the app no longer exits with "Failed to create container." and is instead able to proceed with container creation as usual
- When a different image exists with name `linuxdeepin/apricot:v20.8-compatible` possibly due to malicious tampering, the app now refuses to create the container from the dubious image and instead exits with a clear message
- When a container `deepin-v20` exists that is not based on `linuxdeepin/apricot:v20.8-compatible`, the app refuses to run the container and exits with a clear message